### PR TITLE
Single call to load as many loaders are people wish

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,13 @@ end
 
 ```elixir
 config :weave,
-  file_directory: "path/to/secrets" # Only needed when using the File loader
-  environment_prefix: "MYAPP_"      # Only needed when using the Environment loader
-  handler: Your.Handler             # Always needed :smile:
+  file_directory: "path/to/secrets", # Only needed when using the File loader
+  environment_prefix: "MYAPP_",      # Only needed when using the Environment loader
+  handler: Your.Handler,             # Always needed :smile:
+  loaders: [
+    Weave.Loaders.File,
+    Weave.Loaders.Environment
+  ]
 ```
 
 ### Manual Handler
@@ -89,8 +93,14 @@ NB: For now, `config :weave, handler: BLAH` is still required, even if no `handl
 You'll need to add the following to your `start` function, before you prepare your supervisor:
 
 ```elixir
-Weave.Loaders.File.load_configuration()
+Weave.configure()
+```
+
+If you really wish, you can omit `:loaders` during configuration and load from it manually:
+
+```elixir
 Weave.Loaders.Environment.load_configuration()
+Weave.Loaders.File.load_configuration()
 ```
 
 ### Logging

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,5 @@
 use Mix.Config
 
-config :logger, level: :debug
+config :logger, level: :warn
 
 config :cabbage, features: "feature/"

--- a/feature/loaders/environment.feature
+++ b/feature/loaders/environment.feature
@@ -4,11 +4,11 @@ Feature: It can load configuration from environment variables
   I need to be able to configure my application from environment variables
 
   Scenario: Load configuration
-    Given I have configured weave to load environment variables with prefix "WEAVE_"
-    And I have provided the configuration handler
+    Given I have configured Weave with a handler
+    And I have configured Weave's Environment loader to load environment variables with prefix "WEAVE_"
     And the following environment variables exist
     | key               | value                     |
     | database_host     | my-database-host.com      |
     | database_port     | 6666                      |
-    When I run the Weave file loader
+    When I run Weave's Environment loader
     Then my application should be configured

--- a/feature/loaders/file.feature
+++ b/feature/loaders/file.feature
@@ -4,12 +4,12 @@ Feature: It can load configuration from a configured directory
   I need to be able to configure my application from files on disk
 
   Scenario: Load configuration
-    Given I have configured weave to load configuration from "secrets"
-    And I have provided the configuration handler
+    Given I have configured Weave with a handler
+    And I have configured Weave's File loader to load configuration from "secrets"
     And the directory exists
     And the following files exist there
     | file_name         | contents                  |
     | cookie_secret     | I am super Secur3         |
     | database_password | my-super-secret-password  |
-    When I run the Weave file loader
+    When I run Weave's File loader
     Then my application should be configured

--- a/feature/multiple_loaders.feature
+++ b/feature/multiple_loaders.feature
@@ -1,0 +1,22 @@
+Feature: It can be configured to load configuration using multiple loaders
+  In order to configure my application from different sources
+  As a Developer
+  I need to be able to configure my application with multiple loaders
+
+  Scenario: Load configuration
+    Given I have configured Weave with a handler
+    And I have configured Weave to use multiple loaders
+
+    And I have configured Weave's Environment loader to load environment variables with prefix "WEAVE_"
+    And the following environment variables exist
+    | key               | value                     |
+    | database_host     | my-database-host.com      |
+
+    And I have configured Weave's File loader to load configuration from "secrets"
+    And the directory exists
+    And the following files exist there
+    | file_name         | contents                  |
+    | cookie_secret     | I am super Secur3         |
+
+    When I run Weave.configure
+    Then my application should be configured by both loaders

--- a/lib/weave.ex
+++ b/lib/weave.ex
@@ -1,0 +1,8 @@
+defmodule Weave do
+  def configure() do
+    Application.get_env(:weave, :loaders)
+    |> Enum.map(fn(loader) ->
+      loader.load_configuration()
+    end)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -27,13 +27,13 @@ defmodule Weave.Mixfile do
     [ {:ex_doc, ">= 0.0.0", only: :dev},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
       {:excoveralls, "~> 0.4", only: :test},
-      {:cabbage, "~> 0.3.0", only: :test}
+      {:cabbage, "~> 0.3.1", only: :test}
     ]
   end
 
   def aliases do
     [ "init": ["local.hex --force", "deps.get"],
-      "test": ["init", "test"]
+      "test": ["test"]
     ]
   end
 

--- a/secrets/cookie_secret
+++ b/secrets/cookie_secret
@@ -1,0 +1,1 @@
+I am super Secur3

--- a/test/loaders/environment_test.exs
+++ b/test/loaders/environment_test.exs
@@ -1,32 +1,6 @@
 defmodule Test.Feature.Loaders.Environment do
   use Cabbage.Feature, file: "loaders/environment.feature"
 
-  defgiven ~r/^I have configured weave to load environment variables with prefix "(?<environment_prefix>[^"]+)"$/, %{environment_prefix: environment_prefix}, _state do
-    Application.put_env(:weave, :environment_prefix, environment_prefix)
-    {:ok, %{environment_prefix: environment_prefix}}
-  end
-
-  defand ~r/^I have provided the configuration handler$/, _vars, state do
-    Application.put_env(:weave, :handler, Test.Weave.Handler)
-    {:ok, state}
-  end
-
-  defand ~r/^the following environment variables exist$/, %{table: variables}, state = %{environment_prefix: environment_prefix} do
-    Enum.each(variables, fn(%{key: key, value: value}) ->
-      System.put_env("#{environment_prefix}#{key}", value)
-    end)
-    {:ok, Map.merge(state, %{expected_configuration: variables})}
-  end
-
-  defwhen ~r/^I run the Weave file loader$/, _vars, state do
-    Weave.Loaders.Environment.load_configuration()
-    {:ok, state}
-  end
-
-  defthen ~r/^my application should be configured$/, _vars, %{environment_prefix: environment_prefix, expected_configuration: expected_configuration} do
-    Enum.each(expected_configuration, fn(%{key: key, value: value}) ->
-       assert Application.get_env(:weave, String.to_atom(key)) == value
-    end)
-    {:ok, %{}}
-  end
+  import_steps Test.Feature.Steps.Shared
+  import_steps Test.Feature.Steps.Environment
 end

--- a/test/loaders/file_test.exs
+++ b/test/loaders/file_test.exs
@@ -1,40 +1,6 @@
 defmodule Test.Feature.Loaders.File do
   use Cabbage.Feature, file: "loaders/file.feature"
 
-  defgiven ~r/^I have configured weave to load configuration from "(?<file_directory>[^"]+)"$/, %{file_directory: file_directory}, _state do
-    Application.put_env(:weave, :file_directory, file_directory)
-    {:ok, %{file_directory: file_directory}}
-  end
-
-  defand ~r/^I have provided the configuration handler$/, _vars, state do
-    Application.put_env(:weave, :handler, Test.Weave.Handler)
-    {:ok, state}
-  end
-
-  defand ~r/^the directory exists$/, _vars, state = %{file_directory: file_directory} do
-    File.mkdir_p(file_directory)
-    {:ok, state}
-  end
-
-  defand ~r/^the following files exist there$/, %{table: files}, state = %{file_directory: file_directory} do
-    Enum.each(files, fn(%{file_name: file_name, contents: contents}) ->
-      File.write!("#{file_directory}/#{file_name}", contents)
-    end)
-    {:ok, Map.merge(state, %{expected_configuration: files})}
-  end
-
-  defwhen ~r/^I run the Weave file loader$/, _vars, state do
-    Weave.Loaders.File.load_configuration()
-
-    {:ok, state}
-  end
-
-  defthen ~r/^my application should be configured$/, _vars, %{file_directory: file_directory, expected_configuration: expected_configuration} do
-    File.rm_rf(file_directory)
-
-    Enum.each(expected_configuration, fn(%{file_name: key, contents: value}) ->
-      assert Application.get_env(:weave, String.to_atom(key)) == value
-    end)
-    {:ok, %{}}
-  end
+  import_steps Test.Feature.Steps.Shared
+  import_steps Test.Feature.Steps.File
 end

--- a/test/multiple_loaders_test.exs
+++ b/test/multiple_loaders_test.exs
@@ -1,0 +1,27 @@
+defmodule Test.Feature.MultipleLoaders do
+  use Cabbage.Feature, file: "multiple_loaders.feature"
+
+  import_steps Test.Feature.Steps.Shared
+  import_steps Test.Feature.Steps.Environment
+  import_steps Test.Feature.Steps.File
+
+  defand ~r/^I have configured Weave to use multiple loaders$/, _vars, _state do
+    Application.put_env(:weave, :loaders, [
+      Weave.Loaders.File,
+      Weave.Loaders.Environment
+    ])
+
+    {:ok, %{}}
+  end
+
+  defwhen ~r/^I run Weave.configure$/, _vars, state do
+    Weave.configure()
+
+    {:ok, state}
+  end
+
+  defthen ~r/^my application should be configured by both loaders$/, _vars, _state do
+    assert Application.get_env(:weave, :database_host) == "my-database-host.com"
+    assert Application.get_env(:weave, :cookie_secret, "") == "I am super Secur3"
+  end
+end

--- a/test/steps/environment_steps.ex
+++ b/test/steps/environment_steps.ex
@@ -1,0 +1,27 @@
+defmodule Test.Feature.Steps.Environment do
+  use Cabbage.Feature
+
+  defand ~r/^I have configured Weave's Environment loader to load environment variables with prefix "(?<environment_prefix>[^"]+)"$/, %{environment_prefix: environment_prefix}, state do
+    Application.put_env(:weave, :environment_prefix, environment_prefix)
+    {:ok, Map.merge(state, %{environment_prefix: environment_prefix})}
+  end
+
+  defand ~r/^the following environment variables exist$/, %{table: variables}, state = %{environment_prefix: environment_prefix} do
+    Enum.each(variables, fn(%{key: key, value: value}) ->
+      System.put_env("#{environment_prefix}#{key}", value)
+    end)
+    {:ok, Map.merge(state, %{expected_configuration: variables})}
+  end
+
+  defwhen ~r/^I run Weave's Environment loader$/, _vars, state do
+    Weave.Loaders.Environment.load_configuration()
+    {:ok, state}
+  end
+
+  defthen ~r/^my application should be configured$/, _vars, %{expected_configuration: expected_configuration} do
+    Enum.each(expected_configuration, fn(%{key: key, value: value}) ->
+       assert Application.get_env(:weave, String.to_atom(key)) == value
+    end)
+    {:ok, %{}}
+  end
+end

--- a/test/steps/file_steps.ex
+++ b/test/steps/file_steps.ex
@@ -1,0 +1,34 @@
+defmodule Test.Feature.Steps.File do
+  use Cabbage.Feature
+
+  defand ~r/^I have configured Weave's File loader to load configuration from "(?<file_directory>[^"]+)"$/, %{file_directory: file_directory}, state do
+    Application.put_env(:weave, :file_directory, file_directory)
+    {:ok, Map.merge(state, %{file_directory: file_directory})}
+  end
+
+  defand ~r/^the directory exists$/, _vars, state = %{file_directory: file_directory} do
+    File.mkdir_p(file_directory)
+    {:ok, state}
+  end
+
+  defand ~r/^the following files exist there$/, %{table: files}, state = %{file_directory: file_directory} do
+    Enum.each(files, fn(%{file_name: file_name, contents: contents}) ->
+      File.write!("#{file_directory}/#{file_name}", contents)
+    end)
+    {:ok, Map.merge(state, %{expected_configuration: files})}
+  end
+
+  defwhen ~r/^I run Weave's File loader$/, _vars, state do
+    Weave.Loaders.File.load_configuration()
+    {:ok, state}
+  end
+
+  defthen ~r/^my application should be configured$/, _vars, %{file_directory: file_directory, expected_configuration: expected_configuration} do
+    File.rm_rf(file_directory)
+
+    Enum.each(expected_configuration, fn(%{file_name: key, contents: value}) ->
+      assert Application.get_env(:weave, String.to_atom(key)) == value
+    end)
+    {:ok, %{}}
+  end
+end

--- a/test/steps/shared_steps.ex
+++ b/test/steps/shared_steps.ex
@@ -1,0 +1,8 @@
+defmodule Test.Feature.Steps.Shared do
+  use Cabbage.Feature
+
+  defgiven ~r/^I have configured Weave with a handler$/, _vars, state do
+    Application.put_env(:weave, :handler, Test.Weave.Handler)
+    {:ok, state}
+  end
+end


### PR DESCRIPTION
Allow `:loaders` to be specified in the config, allowing a single call to `Weave.configure()` to load your configuration.