### PR TITLE
Allowing handlers to return :ok and continue

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{ex,exs}]
+indent_style = space
+indent_size = 2

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+TESTS=
+
 clean:
 	@docker-compose down -v
 
@@ -8,7 +10,7 @@ lint:
 	@docker-compose run --rm elixir credo --strict
 
 test:
-	@docker-compose run --rm -e MIX_ENV=test elixir test
+	@docker-compose run --rm -e MIX_ENV=test elixir test $(TESTS)
 
 analyse:
 	@docker-compose run --rm elixir dialyzer

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
 use Mix.Config
 
-config :logger, level: :warn
+config :logger, level: :error
 config :cabbage, features: "feature/"

--- a/example/weave.ex
+++ b/example/weave.ex
@@ -1,13 +1,21 @@
 defmodule MyApp.Weave do
-    @moduledoc """
-    Example Weave Module
-    """
-    use Weave
+  @moduledoc """
+  Example Weave Module
+  """
+  use Weave
 
-    weave "database_host",      required: true,
-        handler: {:example_app, :database_host}
+  weave "database_host",      required: true,
+    handler: {:example_app, :database_host}
 
-    weave "database_password",  handler: {:example_app, :database_password}
-    weave "database_port",      handler: {:example_app, :database_port}
-    weave "cookie_secret",      handler: {:example_app, :cookie_secret}
+  weave "database_password",  handler: {:example_app, :database_password}
+  weave "database_port",      handler: {:example_app, :database_port}
+  weave "cookie_secret",      handler: {:example_app, :cookie_secret}
+
+  weave "multi",              handler: [{:example_app, :one}, {:example_app, :two}]
+
+  weave "log_level",          handler: fn(log_level) ->
+    Logger.configure(level: String.to_atom(log_level))
+
+    :ok
+  end
 end

--- a/lib/loader.ex
+++ b/lib/loader.ex
@@ -41,6 +41,11 @@ defmodule Weave.Loader do
           handle_configuration(name, contents)
       end
 
+      # Allow handlers to return :ok
+      defp configure(:ok) do
+        :ok
+      end
+
       # We're transforming this to a List, as I believe we'll
       # eventually enforce all handle_configuration/1's return List
       defp configure({app, key, value}) do
@@ -84,6 +89,10 @@ defmodule Weave.Loader do
       end
 
       defp merge(old, new) when is_binary(new) do
+        new
+      end
+
+      defp merge(old, new) when is_atom(new) do
         new
       end
 

--- a/test/loader_test.exs
+++ b/test/loader_test.exs
@@ -30,16 +30,21 @@ defmodule Test.Weave.Loader do
     assert "lower_cased" = Test.Weave.Loaders.Test.test_sanitize("lOWEr_CAsED")
   end
 
-  test "It can set multiple configuration keys by returning a list of tuples" do
-    assert :ok = Test.Weave.Loaders.Test.test_apply_configuration("multi", :success, Test.Weave.Handler)
+  test "it can handle :ok (noop)" do
+    assert :ok = Test.Weave.Loaders.Test.test_apply_configuration("log_level", "warn", MyApp.Weave)
+    assert :warn == Logger.level()
+  end
 
-    assert Application.get_env(:weave, :one, :success)
-    assert Application.get_env(:weave, :two, :success)
+  test "It can set multiple configuration keys by returning a list of tuples" do
+    assert :ok = Test.Weave.Loaders.Test.test_apply_configuration("multi", :success, MyApp.Weave)
+
+    assert :success = Application.get_env(:example_app, :one)
+    assert :success = Application.get_env(:example_app, :two)
   end
 
   test "It can detect :auto wiring configuration types" do
     assert :ok = Test.Weave.Loaders.Test.test_handle_configuration("my_app_password", ~s/{:auto, :my_app, :password, "password"}/)
 
-    assert Application.get_env(:my_app, :password) == "password"
+    assert "password" = Application.get_env(:my_app, :password)
   end
 end


### PR DESCRIPTION
As well as allowing handlers to return `:ok`, I noticed that our `multi` test wasn't actually making any assertions ... fixed now though :smile: 